### PR TITLE
feat: cache OS info on mount to avoid redundant client requests

### DIFF
--- a/src-theme/src/integration/types.ts
+++ b/src-theme/src/integration/types.ts
@@ -375,8 +375,10 @@ export interface Component {
     settings: { [name: string]: any };
 }
 
+export type OS = "linux" | "solaris" | "windows" | "mac" | "unknown";
+
 export interface ClientInfo {
-    os: "linux" | "solaris" | "windows" | "mac" | "unknown";
+    os: OS;
     gameVersion: string;
     clientVersion: string;
     clientName: string;

--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import {onMount} from "svelte";
-    import {getGameWindow, getModules, getModuleSettings, setTyping} from "../../integration/rest";
+    import {getClientInfo, getGameWindow, getModules, getModuleSettings, setTyping} from "../../integration/rest";
     import {groupByCategory} from "../../integration/util";
     import type {ConfigurableSetting, GroupedModules, Module, TogglableSetting} from "../../integration/types";
     import Panel from "./Panel.svelte";
@@ -9,7 +9,7 @@
     import {fade} from "svelte/transition";
     import {listen} from "../../integration/ws";
     import type {ClickGuiValueChangeEvent, ScaleFactorChangeEvent} from "../../integration/events";
-    import {gridSize, scaleFactor, showGrid, snappingEnabled} from "./clickgui_store";
+    import {gridSize, os, scaleFactor, showGrid, snappingEnabled} from "./clickgui_store";
 
     let categories: GroupedModules = {};
     let modules: Module[] = [];
@@ -29,6 +29,11 @@
     }
 
     onMount(async () => {
+        await (async () => {
+            const info = await getClientInfo();
+            os.set(info.os)
+        })();
+
         const gameWindow = await getGameWindow();
         minecraftScaleFactor = gameWindow.scaleFactor;
 

--- a/src-theme/src/routes/clickgui/ClickGui.svelte
+++ b/src-theme/src/routes/clickgui/ClickGui.svelte
@@ -29,10 +29,8 @@
     }
 
     onMount(async () => {
-        await (async () => {
-            const info = await getClientInfo();
-            os.set(info.os)
-        })();
+        const info = await getClientInfo();
+        os.set(info.os);
 
         const gameWindow = await getGameWindow();
         minecraftScaleFactor = gameWindow.scaleFactor;

--- a/src-theme/src/routes/clickgui/clickgui_store.ts
+++ b/src-theme/src/routes/clickgui/clickgui_store.ts
@@ -7,6 +7,8 @@ export interface TDescription {
     y: number;
 }
 
+export const os: Writable<string | null> = writable<string | null>(null);
+
 export const description: Writable<TDescription | null> = writable(null);
 
 export const maxPanelZIndex: Writable<number> = writable(0);

--- a/src-theme/src/routes/clickgui/setting/bind/BindDisplay.svelte
+++ b/src-theme/src/routes/clickgui/setting/bind/BindDisplay.svelte
@@ -1,43 +1,44 @@
 <script lang="ts">
     import type {BindModifier} from "../../../../integration/types";
-    import {getClientInfo} from "../../../../integration/rest";
+    import {os} from "../../clickgui_store";
 
     export let modifiers: Iterable<BindModifier>;
     export let boundKey: string | undefined;
 
-    const getRenderString = (modifier: BindModifier) => getClientInfo().then(({ os }) => {
-        switch (os) {
+    const getRenderString = (modifier: BindModifier) => {
+        switch ($os) {
             case "windows":
                 switch (modifier) {
-                    case "Control": return "Ctrl";
-                    case "Super": return "\u229e";
-                    default: return modifier;
+                    case "Control":
+                        return "Ctrl";
+                    case "Super":
+                        return "\u229e";
+                    default:
+                        return modifier;
                 }
             case "mac":
                 switch (modifier) {
-                    case "Shift": return "\u21e7";
-                    case "Control": return "^";
-                    case "Alt": return "\u2325";
-                    case "Super": return "\u2318";
-                    default: return modifier;
+                    case "Shift":
+                        return "\u21e7";
+                    case "Control":
+                        return "^";
+                    case "Alt":
+                        return "\u2325";
+                    case "Super":
+                        return "\u2318";
+                    default:
+                        return modifier;
                 }
-            default: return modifier;
+            default:
+                return modifier;
         }
-    });
+    };
 </script>
 
 <span class="wrapper">
     {#if boundKey}
         {#each modifiers as modifier (modifier)}
-            <span>
-                {#await getRenderString(modifier)}
-                    {modifier}
-                {:then osModifier}
-                    {osModifier}
-                {:catch error}
-                    {modifier}
-                {/await}
-            </span>
+            <span>{getRenderString(modifier)}</span>
             <span class="divider">+</span>
         {/each}
         <span class="boundKey">{boundKey}</span>


### PR DESCRIPTION
Retrieve and store OS information once on clickgui mount, preventing repeated client info fetches on every bind. This optimizes performance by reducing unnecessary async & fetch calls.